### PR TITLE
Ajout des restrictions Admin sur la page des utilisateurs

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,4 +1,7 @@
 security:
+    access_decision_manager:
+        strategy: unanimous
+        allow_if_all_abstain: false
     enable_authenticator_manager: true
 
     password_hashers:
@@ -29,11 +32,18 @@ security:
                 lifetime: 604800
                 path: /
                 always_remember_me: true
+            access_denied_handler: App\Security\AccessDeniedHandler
+         # activate different ways to authenticate
+            # https://symfony.com/doc/current/security.html#the-firewall
+
+            # https://symfony.com/doc/current/security/impersonating_user.html
+            # switch_user: true
+
+    # Easy way to control access for large sections of your site
+    # Note: Only the *first* access control that matches will be used
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }        
-
-
+        # - { path: ^/profile, roles: ROLE_USER }
 when@test:
     security:
         password_hashers:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,3 +26,10 @@ services:
         tags: ['controller.service_arguments']
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    
+    App\Security\Voter\UserVoter:
+        tags:
+            - { name: security.voter }
+
+    App\Security\AccessDeniedHandler:
+        tags: ['monolog.logger']

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -37,7 +37,7 @@ class TaskController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            
+
             $user = $security->getUser();
             if (!$user) {
                 throw new AccessDeniedException('Vous devez être connecté pour créer une tâche.');
@@ -112,4 +112,3 @@ class TaskController extends AbstractController
         return $this->redirectToRoute('task_list');
     }
 }
-

--- a/src/Security/AccessDeniedHandler.php
+++ b/src/Security/AccessDeniedHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class AccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response
+    {
+        // Add flash message
+        $request->getSession()->getFlashBag()->add('error', 'Vous n\'avez pas les permissions nécessaires pour accéder à cette page.');
+
+        // Redirect to homepage
+        return new RedirectResponse($this->router->generate('homepage'));
+    }
+}

--- a/src/Security/Voter/TaskVoter.php
+++ b/src/Security/Voter/TaskVoter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Security\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class TaskVoter extends Voter
+{
+    public const EDIT = 'POST_EDIT';
+    public const VIEW = 'POST_VIEW';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        // replace with your own logic
+        // https://symfony.com/doc/current/security/voters.html
+        return in_array($attribute, [self::EDIT, self::VIEW])
+            && $subject instanceof \App\Entity\Task;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        // if the user is anonymous, do not grant access
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        // ... (check conditions and return true to grant permission) ...
+        switch ($attribute) {
+            case self::EDIT:
+                // logic to determine if the user can EDIT
+                // return true or false
+                break;
+
+            case self::VIEW:
+                // logic to determine if the user can VIEW
+                // return true or false
+                break;
+        }
+
+        return false;
+    }
+}

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Security\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+use App\Entity\User;
+
+class UserVoter extends Voter
+{
+    public const VIEW = 'USER_VIEW';
+    public const EDIT = 'USER_EDIT';
+    public const DELETE = 'USER_DELETE';
+
+    protected function supports(string $attribute, $subject): bool
+    {
+        return in_array($attribute, [self::VIEW, self::EDIT, self::DELETE]) && $subject instanceof User;
+    }
+
+    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        /** @var User $subject */
+        switch ($attribute) {
+            case self::VIEW:
+                return $this->canView($user);
+            case self::EDIT:
+                return $this->canEdit($subject, $user);
+            case self::DELETE:
+                return $this->canDelete($subject, $user);
+        }
+
+        return false;
+    }
+
+    private function canView(User $user): bool
+    {
+        return in_array('ROLE_ADMIN', $user->getRoles());
+    }
+
+    private function canEdit(User $subject, User $user): bool
+    {
+        return in_array('ROLE_ADMIN', $user->getRoles());
+    }
+
+    private function canDelete(User $subject, User $user): bool
+    {
+        return in_array('ROLE_ADMIN', $user->getRoles());
+    }
+}

--- a/templates/user/list.html.twig
+++ b/templates/user/list.html.twig
@@ -29,6 +29,9 @@
                         <td>
                             <a href="{{ path('user_edit', {'id' : user.id}) }}" class="btn btn-success btn-sm">Edit</a>
                         </td>
+                         <td>
+                            <a href="{{ path('user_delete', {'id' : user.id}) }}" class="btn btn-danger btn-sm">Supprimer</a>
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
- Ajout d'un Voter Symfony "UserVoter" pour restreindre l'accès aux pages en fonction des rôles de l'utilisateur.
- Déclaration de l'AccessDeniedHandler dans le fichier security.yaml, ainsi que la déclaration du UserVoter et de l'AccessDeniedHandler dans le fichier services.yaml.
- Création du fichier AccessDeniedHandler.php pour gérer les messages personnalisés.
- Utilisation de "denyAccessUnlessGranted" dans chaque fonction du fichier UserController.php.